### PR TITLE
timer mixin for ES6 classes

### DIFF
--- a/TimerMixin.js
+++ b/TimerMixin.js
@@ -55,19 +55,6 @@ var _rafs = 'TimerMixin_rafs';
 var _cancelAnimationFrame = clearer(GLOBAL.cancelAnimationFrame, _rafs);
 var _requestAnimationFrame = setter(GLOBAL.requestAnimationFrame, _cancelAnimationFrame, _rafs);
 
-var TimerMixin = {
-  setTimeout: _setTimeout,
-  clearTimeout: _clearTimeout,
-
-  setInterval: _setInterval,
-  clearInterval: _clearInterval,
-
-  setImmediate: _setImmediate,
-  clearImmediate: _clearImmediate,
-
-  requestAnimationFrame: _requestAnimationFrame,
-  cancelAnimationFrame: _cancelAnimationFrame,
-};
 
 var componentWillUnmount = function() {
   this[_timeouts] && this[_timeouts].forEach(function(id) {
@@ -88,8 +75,27 @@ var componentWillUnmount = function() {
   this[_rafs] = null;
 };
 
+var TimerMixin = {
+  componentWillUnmount: componentWillUnmount,
+  setTimeout: _setTimeout,
+  clearTimeout: _clearTimeout,
 
-module.exports = function Timer(Component) {
+  setInterval: _setInterval,
+  clearInterval: _clearInterval,
+
+  setImmediate: _setImmediate,
+  clearImmediate: _clearImmediate,
+
+  requestAnimationFrame: _requestAnimationFrame,
+  cancelAnimationFrame: _cancelAnimationFrame,
+};
+
+
+module.exports = Object.assign({
+  componentWillUnmount: componentWillUnmount,
+}, TimerMixin);
+
+module.exports.Timer = function Timer(Component) {
   class TimerComponent extends Component {
     constructor(...args) {
       super(...args);

--- a/TimerMixin.js
+++ b/TimerMixin.js
@@ -89,9 +89,7 @@ var componentWillUnmount = function() {
 };
 
 
-module.exports = TimerMixin;
-
-module.exports.Timer = function (Component) {
+module.exports = function Timer(Component) {
   class TimerComponent extends Component {
     constructor(...args) {
       super(...args);

--- a/TimerMixin.js
+++ b/TimerMixin.js
@@ -88,4 +88,16 @@ var TimerMixin = {
   cancelAnimationFrame: _cancelAnimationFrame,
 };
 
+
+
 module.exports = TimerMixin;
+
+module.exports.Timer function (Component) {
+  class TimerComponent extends Component {
+    //note within your own componentWillUnmount method you will need to call super()
+  }
+
+  Object.assign(TimerComponent.prototype, TimerMixin);
+
+  return TimerComponent;
+};

--- a/TimerMixin.js
+++ b/TimerMixin.js
@@ -92,7 +92,7 @@ var TimerMixin = {
 
 module.exports = TimerMixin;
 
-module.exports.Timer function (Component) {
+module.exports.Timer = function (Component) {
   class TimerComponent extends Component {
     //note within your own componentWillUnmount method you will need to call super()
   }


### PR DESCRIPTION
if you create your own `componentWillUnmount` method, you won't have to call super, which would defeat the purpose of the timer cleanup automation this package provides. 

Usage:

```
import {Timer} from 'react-timer-mixin';

class MyComponent extends Timer(React.Component) {
...
}
```
