### PR TITLE
Change the order of preference for setting GLOBAL

### DIFF
--- a/TimerMixin.js
+++ b/TimerMixin.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-var GLOBAL = typeof window === 'undefined' ? global : window;
+var GLOBAL = typeof global === 'undefined' ? window : global;
 
 var setter = function(_setter, _clearer, array) {
   return function(callback, delta) {


### PR DESCRIPTION
When using _jsdom_ in combination with _Enzyme_ for testing _react-native_ using _jest_ we run into an error where `window.requestAnimationFrame` is undefined. However, running in the node context, `global.requestAnimationFrame` is made available when testing. Since GLOBAL preferred `window` over `global` when both exist it causes errors in testing React-Native applications in Jest and jsdom.

For example, the following code causes TimerMixin to fail when testing a React application.

```javascript
var jsdom = require('jsdom').jsdom;
global.document = jsdom('');
global.window = document.defaultView;
Object.keys(document.defaultView).forEach((property) => {
    if (typeof global[property] === 'undefined') {
        global[property] = document.defaultView[property];
    }
});
global.navigator = {
    userAgent: 'node.js'
};
```

You can see `global.window` is being set, and will definitely cause TimerMixin to fail. It would be safer even in web contexts when assuming `window.global` would be undefined.

Read more here at AirBnb docs. http://airbnb.io/enzyme/docs/guides/jsdom.html